### PR TITLE
use the current dirs name instead of env variable and remove sass reb…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "watch": "npm rebuild node-sass && node node_modules/webpack/bin/webpack.js --watch --config webpack.config.js",
-    "build": "npm rebuild node-sass && node node_modules/webpack/bin/webpack.js --optimize-minimize --config webpack.production.config.js"
+    "build": "node node_modules/webpack/bin/webpack.js --optimize-minimize --config webpack.production.config.js"
   },
   "repository": "ssh://git@gitlab.dev.e-vista.hu:2828/wp/evista-starter-theme-sass.git",
   "author": "Schutzbach Zsolt <schutzbach.zsolt@e-vista.hu>",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -2,11 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
-if (!process.env.WPTHEME) {
-  throw new Error('WPTHEME env variable is unset. Please set it to the current folder\'s name.')
-}
-
-const themeName = (process.env.WPTHEME).trim()
+const themeName = path.basename(process.cwd())
 
 const configs = [{
   entry: './assets/index.js',


### PR DESCRIPTION
Use the current dirs name instead of env variable in webpack build config and remove sass rebuild before builds (only needed on windows where usually nobody builds)